### PR TITLE
let specify a newline in kail prefix format

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,15 @@ for input and snazzily print your logs from the stream (one line at a time).
 
 ![screenshot](./.github/screenshot-kail.png)
 
-* If you want to customize the kail format, you can do it with the flag
-  `--kail-prefix-format` it will replace the variable `{namespace} {pod}
-  {container}` by its value. If you for example only want to print the `pod` you can do :
+* The flag "--kail-prefix-format" let you customize how to display the kail
+  format, the templates `{namespace}`, `{pod}`, `{container}` will be replaced
+  by its value and a "\n" will be replaced by a newline. As an example if you
+  want to only show the current pod following by a newline you can use the
+  following template:
 
      `--kail-prefix-format "{pod}"`
 
-  or set the environement variable `SNAZY_KAIL_PREFIX_FORMAT` to make it permanent.
+  the environement variable `SNAZY_KAIL_PREFIX_FORMAT` let you make this setting permanent.
 
 * If you do not any prefix for kail you can pass the `--kail-no-prefix` flag.
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -105,7 +105,8 @@ fn parse_kail_lines(config: &Config, rawline: &str) -> Option<String> {
     kail_msg_prefix = kail_msg_prefix
         .replace("{namespace}", namespace)
         .replace("{pod}", pod)
-        .replace("{container}", container);
+        .replace("{container}", container)
+        .replace("\\n", "\n");
     Some(kail_msg_prefix)
 }
 

--- a/src/parse_test.rs
+++ b/src/parse_test.rs
@@ -37,6 +37,20 @@ mod tests {
     }
 
     #[test]
+    fn test_kail_newline() {
+        let line = r#"ns/pod[container]: {"severity":"INFO","timestamp":"2022-04-25T14:20:32.505637358Z","logger":"pipelinesascode","caller":"pipelineascode/status.go:59","message":"updated","provider":"github","event":"8b400490-c4a1-11ec-9219-63bc5bbc8228"}"#;
+        let msg = extract_info(
+            line,
+            &Config {
+                kail_no_prefix: false,
+                kail_prefix_format: String::from("{container}\n"),
+                ..config::Config::default()
+            },
+        );
+        assert!(msg["msg"].contains("container\n"));
+    }
+
+    #[test]
     fn test_kail_no_prefix() {
         let line = r#"ns/pod[container]: {"severity":"INFO","timestamp":"2022-04-25T14:20:32.505637358Z","logger":"pipelinesascode","caller":"pipelineascode/status.go:59","message":" updated","provider":"github","event":"8b400490-c4a1-11ec-9219-63bc5bbc8228"}"#;
         let msg = extract_info(


### PR DESCRIPTION
this allows breaking the prefix when too long 

![image](https://user-images.githubusercontent.com/98980/169832172-f090845a-11b1-4398-aa51-fbd702b9a002.png)
