### PR TITLE
feat: Add stacktrace parsing display highlighting control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bumpalo"
@@ -96,9 +96,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "shlex",
 ]
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94fea34d77a245229e7746bd2beb786cd2a896f306ff491fb8cecb3074b10a7"
+checksum = "8f10f8c9340e31fc120ff885fcdb54a0b48e474bbd77cab557f0c30a3e569402"
 dependencies = [
  "parse-zoneinfo",
  "phf_codegen",
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.34"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.34"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -226,9 +226,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -242,14 +242,14 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
+ "r-efi",
  "wasi",
- "windows-targets",
 ]
 
 [[package]]
@@ -266,14 +266,15 @@ checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -306,9 +307,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -322,21 +323,21 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
@@ -371,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "parse-zoneinfo"
@@ -424,21 +425,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -486,9 +493,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags",
  "errno",
@@ -499,15 +506,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "serde"
@@ -531,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -578,9 +585,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -602,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "utf8parse"
@@ -614,9 +621,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -681,18 +688,62 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -769,9 +820,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]

--- a/README.md
+++ b/README.md
@@ -157,6 +157,19 @@ are supported for now (ie: no rgb or fixed):
   kubectl logs deployment/controller | snazy --timezone America/New_York
   ```
 
+- You can disable the display of stacktraces in error logs using the
+`--hide-stacktrace` flag (or the environment variable `SNAZY_HIDE_STACKTRACE`).
+By default, when a stacktrace is found in the log entry, snazy will display it
+with syntax highlighting. This option allows you to keep your output more
+compact by hiding stacktraces.
+
+  ```shell
+  kubectl logs deployment/controller | snazy --hide-stacktrace
+  ```
+
+  additionally if snazy detects a stacktrace with filename and line number it
+  will highlight it with a different color.
+
 - If you want to skip showing some lines you can specify the flag
   `-S/--skip-line-regexp`. When it matches the word or regexp in
   this value it will simply skipping printing the line. You can have multiple flags

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -121,6 +121,10 @@ struct Args {
     ///  The command to run when a regexp match the --action-match
     pub action_command: Option<String>,
 
+    #[arg(long, action(clap::ArgAction::SetTrue), env = "SNAZY_HIDE_STACKTRACE")]
+    /// Hide stacktraces in the log output
+    pub hide_stacktrace: bool,
+
     #[arg(value_hint = ValueHint::FilePath)]
     files: Option<Vec<String>>,
 }
@@ -260,5 +264,6 @@ pub fn build_cli_config() -> Config {
         files: args.files,
         regexp_colours,
         json_keys,
+        hide_stacktrace: args.hide_stacktrace,
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,7 @@ pub struct Config {
     pub skip_line_regexp: Vec<String>,
     pub time_format: String,
     pub timezone: Option<String>,
+    pub hide_stacktrace: bool,
 }
 
 impl Default for Config {
@@ -63,6 +64,7 @@ impl Default for Config {
             action_regexp: Some(String::new()),
             action_command: Some(String::new()),
             skip_line_regexp: Vec::new(),
+            hide_stacktrace: false,
         }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -41,6 +41,7 @@ pub struct Info {
     msg: String,
     timestamp: String,
     others: String,
+    stacktrace: Option<String>,
 }
 
 pub fn extract_info(rawline: &str, config: &Config) -> HashMap<String, String> {
@@ -59,6 +60,14 @@ pub fn extract_info(rawline: &str, config: &Config) -> HashMap<String, String> {
 
     if !config.json_keys.is_empty() {
         msg = custom_json_match(config, time_format, &kail_msg_prefix, line.as_str());
+    }
+
+    // Try to parse as a generic JSON to extract stacktrace field
+    // regardless of the specific log format
+    if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(&line) {
+        if let Some(stacktrace) = json_value.get("stacktrace").and_then(|s| s.as_str()) {
+            msg.insert("stacktrace".to_string(), stacktrace.to_string());
+        }
     }
 
     if let Ok(p) = serde_json::from_str::<Pac>(line.as_str()) {
@@ -80,6 +89,13 @@ pub fn extract_info(rawline: &str, config: &Config) -> HashMap<String, String> {
                 msg.insert("others".to_string(), format!("{others} "));
             }
         }
+
+        // Extract stacktrace from Pac struct if available
+        if p.other.contains_key("stacktrace") {
+            if let Some(stacktrace) = p.other["stacktrace"].as_str() {
+                msg.insert("stacktrace".to_string(), stacktrace.to_string());
+            }
+        }
     }
 
     if let Ok(p) = serde_json::from_str::<Knative>(line.as_str()) {
@@ -90,7 +106,14 @@ pub fn extract_info(rawline: &str, config: &Config) -> HashMap<String, String> {
                 String::from("ts"),
                 crate::utils::convert_ts_float_or_str(ts, time_format, timezone),
             );
-        };
+        }
+
+        // Extract stacktrace from Knative struct if available
+        if p.other.contains_key("stacktrace") {
+            if let Some(stacktrace) = p.other["stacktrace"].as_str() {
+                msg.insert("stacktrace".to_string(), stacktrace.to_string());
+            }
+        }
     }
 
     if !config.kail_no_prefix && !kail_msg_prefix.is_empty() && msg.contains_key("msg") {
@@ -194,11 +217,16 @@ pub fn do_line(config: &Config, line: &str) -> Option<Info> {
     if !config.regexp_colours.is_empty() {
         themsg = apply_regexps(&config.regexp_colours, themsg);
     }
+
+    // Get stacktrace if available
+    let stacktrace = msg.get("stacktrace").map(std::string::ToString::to_string);
+
     Some(Info {
         level,
         timestamp: ts,
         others: other,
         msg: themsg,
+        stacktrace,
     })
 }
 
@@ -212,6 +240,24 @@ pub fn read_from_stdin(config: &Arc<Config>) {
                 "{} {} {}{}",
                 info.level, info.timestamp, info.others, info.msg
             );
+
+            // Display stacktrace if available with prettier formatting
+            if let Some(stack) = &info.stacktrace {
+                // Only display stacktrace if hide_stacktrace is false
+                if !config.hide_stacktrace {
+                    println!("\n{}", "─".repeat(80).fixed(8));
+                    println!("{}", " Stacktrace:".red().bold());
+
+                    // Format each line of the stacktrace with color highlighting
+                    for stack_line in stack.lines() {
+                        // Format the line with colored components
+                        let formatted_line = format_stack_line(stack_line);
+                        println!("   {formatted_line}");
+                    }
+
+                    println!("{}\n", "─".repeat(80).fixed(8));
+                }
+            }
         }
     }
 }
@@ -233,6 +279,24 @@ pub fn read_a_file(config: &Config, filename: &str, writeto: &mut dyn io::Write)
                 info.level, info.timestamp, info.others, info.msg
             )
             .unwrap();
+
+            // Display stacktrace if available with prettier formatting
+            if let Some(stack) = &info.stacktrace {
+                // Only display stacktrace if hide_stacktrace is false
+                if !config.hide_stacktrace {
+                    writeln!(writeto, "\n{}", "─".repeat(80).fixed(8)).unwrap();
+                    writeln!(writeto, "{}", " Stacktrace:".red().bold()).unwrap();
+
+                    // Format each line of the stacktrace with color highlighting
+                    for stack_line in stack.lines() {
+                        // Format the line with colored components
+                        let formatted_line = format_stack_line(stack_line);
+                        writeln!(writeto, "   {formatted_line}").unwrap();
+                    }
+
+                    writeln!(writeto, "{}\n", "─".repeat(80).fixed(8)).unwrap();
+                }
+            }
         }
     }
 }
@@ -246,4 +310,65 @@ pub fn read_from_files(config: &Arc<Config>) {
         let mut stdout = io::BufWriter::new(stdout);
         read_a_file(config, filename, &mut stdout);
     }
+}
+
+// Format a line of stacktrace with colored components
+fn format_stack_line(line: &str) -> String {
+    // Check if this is a file path line with line numbers (contains a colon with numbers after it)
+    if line.contains(".go:")
+        || line.contains(".rs:")
+        || line.contains(".js:")
+        || line.contains(".py:")
+    {
+        // Format lines with file paths and line numbers
+        if let Some(last_slash_pos) = line.rfind('/') {
+            // Extract the filename and path
+            let path = &line[0..=last_slash_pos];
+            let rest = &line[last_slash_pos + 1..];
+
+            // Try to split on colon to separate filename from line number
+            if let Some(colon_pos) = rest.find(':') {
+                let filename = &rest[0..colon_pos];
+                let line_num = &rest[colon_pos + 1..];
+
+                // Return colored parts
+                return format!(
+                    "{}{}{}",
+                    path.fixed(15),                 // Path in dim gray
+                    filename.yellow().bold(),       // Filename in bright yellow
+                    format!(":{line_num}").green()  // Line number in green
+                );
+            }
+
+            // If no colon found, just color the filename
+            return format!("{}{}", path.fixed(15), rest.yellow().bold());
+        }
+
+        // If no slash found, check for a colon to split filename and line number
+        if let Some(colon_pos) = line.find(':') {
+            let filename = &line[0..colon_pos];
+            let line_num = &line[colon_pos + 1..];
+
+            return format!(
+                "{}{}",
+                filename.yellow().bold(),
+                format!(":{line_num}").green()
+            );
+        }
+    }
+
+    // Format function name lines
+    if let Some(dot_pos) = line.rfind('.') {
+        let package_path = &line[0..=dot_pos];
+        let func_name = &line[dot_pos + 1..];
+
+        return format!(
+            "{}{}",
+            package_path.fixed(15),  // Package path in dim gray
+            func_name.cyan().bold()  // Function name in cyan
+        );
+    }
+
+    // Default formatting if no patterns matched
+    line.fixed(15).to_string()
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -193,6 +193,22 @@ snazytest!(
     false
 );
 
+snazytest!(
+    stacktrace_default_display,
+    [""],
+    r#"{"level":"error","ts":"2022-04-25T14:20:32.505637358Z","msg":"Something went wrong","stacktrace":"github.com/example/app.Function\n\tat app.go:42\n\tat main.go:15"}"#,
+    "Stacktrace",
+    true
+);
+
+snazytest!(
+    stacktrace_hidden,
+    ["--hide-stacktrace"],
+    r#"{"level":"error","ts":"2022-04-25T14:20:32.505637358Z","msg":"Something went wrong","stacktrace":"github.com/example/app.Function\n\tat app.go:42\n\tat main.go:15"}"#,
+    "ERROR              14:20:32 Something went wrong\n",
+    false
+);
+
 #[test]
 #[should_panic]
 fn all_json_keys_need_tobe_specified() {


### PR DESCRIPTION
*   Parsed stacktrace information from JSON log entries if present.
*   Displayed detected stacktraces below the corresponding log message.
*   Implemented syntax highlighting for stacktrace elements like file paths,
filenames, line numbers, and function names for better readability.
*   Introduced a `--hide-stacktrace` flag and `SNAZY_HIDE_STACKTRACE`
environment variable to optionally disable stacktrace display for cleaner
output.
*   Updated documentation to include the new feature.

![image](https://github.com/user-attachments/assets/feef4036-833d-43f1-a9a0-e6c70e81569b)
